### PR TITLE
The system was getting SitePrism and Capybara aliased functions mixed…

### DIFF
--- a/lib/cornucopia/capybara/finder_extensions.rb
+++ b/lib/cornucopia/capybara/finder_extensions.rb
@@ -11,8 +11,8 @@ module Cornucopia
       extend ActiveSupport::Concern
 
       included do
-        alias_method :__cornucopia_orig_find, :find
-        alias_method :__cornucopia_orig_all, :all
+        alias_method :__cornucopia_capybara_orig_find, :find
+        alias_method :__cornucopia_capybara_orig_all, :all
 
         define_method :find do |*args, &block|
           __cornucopia_finder_function(:find, *args, &block)
@@ -31,12 +31,12 @@ module Cornucopia
 
         begin
           retry_count += 1
-          result      = send("__cornucopia_orig_#{finder_function}", *args, &block)
+          result      = send("__cornucopia_capybara_orig_#{finder_function}", *args, &block)
         rescue Selenium::WebDriver::Error::StaleElementReferenceError
           retry if __cornucopia__retry_finder(retry_count, support_options)
 
           result = __cornucopia__analyze_finder(finder_function, support_options, *args, &block)
-        rescue Exception
+        rescue StandardError
           result = __cornucopia__analyze_finder(finder_function, support_options, *args, &block)
         end
 

--- a/lib/cornucopia/capybara/matcher_extensions.rb
+++ b/lib/cornucopia/capybara/matcher_extensions.rb
@@ -11,10 +11,10 @@ module Cornucopia
       extend ActiveSupport::Concern
 
       included do
-        alias_method :__cornucopia_orig_assert_selector, :assert_selector
-        alias_method :__cornucopia_orig_assert_no_selector, :assert_no_selector
-        alias_method :__cornucopia_orig_has_selector?, :has_selector?
-        alias_method :__cornucopia_orig_has_no_selector?, :has_no_selector?
+        alias_method :__cornucopia_capybara_orig_assert_selector, :assert_selector
+        alias_method :__cornucopia_capybara_orig_assert_no_selector, :assert_no_selector
+        alias_method :__cornucopia_capybara_orig_has_selector?, :has_selector?
+        alias_method :__cornucopia_capybara_orig_has_no_selector?, :has_no_selector?
 
         define_method :assert_selector do |*args|
           __cornucopia_assert_selector_function(:assert_selector, *args)
@@ -59,7 +59,7 @@ module Cornucopia
 
         begin
           retry_count += 1
-          result      = send("__cornucopia_orig_#{assert_selector_function}", *args)
+          result      = send("__cornucopia_capybara_orig_#{assert_selector_function}", *args)
         rescue Selenium::WebDriver::Error::StaleElementReferenceError
           retry if __cornucopia__retry_selector(retry_count, support_options)
 

--- a/lib/cornucopia/site_prism/element_extensions.rb
+++ b/lib/cornucopia/site_prism/element_extensions.rb
@@ -9,13 +9,13 @@ module Cornucopia
 
       included do
         ::Capybara::Session::DSL_METHODS.each do |method|
-          alias_method "__cornucopia_orig_#{method}".to_sym, method
+          alias_method "__cornucopia_site_prism_orig_#{method}".to_sym, method
 
           define_method method do |*args, &block|
             if @__corunucopia_base_node
               @__corunucopia_base_node.send method, *args, &block
             else
-              send "__cornucopia_orig_#{method}", *args, &block
+              send "__cornucopia_site_prism_orig_#{method}", *args, &block
             end
           end
         end

--- a/lib/cornucopia/site_prism/section_extensions.rb
+++ b/lib/cornucopia/site_prism/section_extensions.rb
@@ -9,10 +9,10 @@ module Cornucopia
 
       included do |base|
         base.class_exec do
-          alias :__cornucopia_orig_initialize :initialize
+          alias :__cornucopia_site_prism_orig_initialize :initialize
 
           def initialize(*args)
-            __cornucopia_orig_initialize(*args)
+            __cornucopia_site_prism_orig_initialize(*args)
 
             self.owner_node = args[0].owner_node
           end

--- a/lib/cornucopia/version.rb
+++ b/lib/cornucopia/version.rb
@@ -1,3 +1,3 @@
 module Cornucopia
-  VERSION = "0.1.52"
+  VERSION = "0.1.53"
 end

--- a/spec/lib/capybara/finder_extensions_spec.rb
+++ b/spec/lib/capybara/finder_extensions_spec.rb
@@ -47,7 +47,7 @@ describe Cornucopia::Capybara::FinderExtensions, type: :feature do
         num_calls   = 0
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_all) do |*args|
+            to receive(:__cornucopia_capybara_orig_all) do |*args|
           num_calls += 1
 
           if time_count > 0
@@ -62,7 +62,7 @@ describe Cornucopia::Capybara::FinderExtensions, type: :feature do
         second_found = contents_frame.all("a")
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_all).
+            to receive(:__cornucopia_capybara_orig_all).
                 and_call_original
 
         # I realize that this is almost like testing that the stub worked, which we don't need to test.
@@ -89,14 +89,14 @@ describe Cornucopia::Capybara::FinderExtensions, type: :feature do
                 and_return(found_elements)
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_all) do |*args|
+            to receive(:__cornucopia_capybara_orig_all) do |*args|
           raise Selenium::WebDriver::Error::StaleElementReferenceError.new
         end
 
         second_found = contents_frame.all("a")
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_all).
+            to receive(:__cornucopia_capybara_orig_all).
                 and_call_original
 
         # I realize that this is almost like testing that the stub worked, which we don't need to test.
@@ -121,14 +121,14 @@ describe Cornucopia::Capybara::FinderExtensions, type: :feature do
                 and_return(found_elements)
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_find) do |*args|
+            to receive(:__cornucopia_capybara_orig_find) do |*args|
           raise "This is an error"
         end
 
         second_found = contents_frame.find(".report-block")
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_find).
+            to receive(:__cornucopia_capybara_orig_find).
                 and_call_original
 
         # I realize that this is almost like testing that the stub worked, which we don't need to test.

--- a/spec/lib/capybara/matcher_extensions_spec.rb
+++ b/spec/lib/capybara/matcher_extensions_spec.rb
@@ -47,7 +47,7 @@ describe Cornucopia::Capybara::MatcherExtensions, type: :feature do
         num_calls   = 0
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_assert_selector) do |*args|
+            to receive(:__cornucopia_capybara_orig_assert_selector) do |*args|
           num_calls += 1
 
           if time_count > 0
@@ -62,7 +62,7 @@ describe Cornucopia::Capybara::MatcherExtensions, type: :feature do
         second_found = contents_frame.assert_selector("a")
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_assert_selector).
+            to receive(:__cornucopia_capybara_orig_assert_selector).
                    and_call_original
 
         # I realize that this is almost like testing that the stub worked, which we don't need to test.
@@ -89,14 +89,14 @@ describe Cornucopia::Capybara::MatcherExtensions, type: :feature do
                    and_return(found_elements)
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_assert_selector) do |*args|
+            to receive(:__cornucopia_capybara_orig_assert_selector) do |*args|
           raise Selenium::WebDriver::Error::StaleElementReferenceError.new
         end
 
         second_found = contents_frame.assert_selector("a")
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_assert_selector).
+            to receive(:__cornucopia_capybara_orig_assert_selector).
                    and_call_original
 
         # I realize that this is almost like testing that the stub worked, which we don't need to test.
@@ -121,14 +121,14 @@ describe Cornucopia::Capybara::MatcherExtensions, type: :feature do
                    and_return(found_elements)
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_assert_no_selector) do |*args|
+            to receive(:__cornucopia_capybara_orig_assert_no_selector) do |*args|
           raise "This is an error"
         end
 
         second_found = contents_frame.assert_no_selector(".report-block")
 
         allow(contents_frame.page.document).
-            to receive(:__cornucopia_orig_assert_no_selector).
+            to receive(:__cornucopia_capybara_orig_assert_no_selector).
                    and_call_original
 
         # I realize that this is almost like testing that the stub worked, which we don't need to test.


### PR DESCRIPTION
… up resulting in an infinite loop.  This dis-ambiguates the two in the rare cases where it matters.